### PR TITLE
Test assertions enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
-  - hhvm
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ dist: trusty
 php:
   - '7.0'
   - '7.1'
-  - 'hhvm'
+  - '7.2'
+  - hhvm
+  - nightly
+matrix:
+  allow_failures:
+    - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "mledoze/countries": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "php-coveralls/php-coveralls": "^2.0",
         "roave/security-advisories": "dev-master"
     },
@@ -21,6 +21,11 @@
     "autoload": {
         "psr-4": {
             "DivineOmega\\Countries\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "DivineOmega\\Countries\\Tests\\": "tests/"
         }
     }
 }

--- a/tests/Unit/BasicUsageTest.php
+++ b/tests/Unit/BasicUsageTest.php
@@ -13,7 +13,7 @@ final class BasicUsageTest extends TestCase
         $this->assertGreaterThanOrEqual(248, count($countries));
 
         foreach ($countries as $country) {
-            $this->assertEquals(Country::class, get_class($country));
+            $this->assertInstanceOf(Country::class, $country);
         }
     }
 
@@ -21,7 +21,7 @@ final class BasicUsageTest extends TestCase
     {
         $country = (new Countries())->getByName('United Kingdom');
 
-        $this->assertEquals(Country::class, get_class($country));
+        $this->assertInstanceOf(Country::class, $country);
         $this->assertEquals('GBR', $country->isoCodeAlpha3);
     }
 
@@ -29,14 +29,14 @@ final class BasicUsageTest extends TestCase
     {
         $country = (new Countries())->getByName('Unified Kingdom of Jordania');
 
-        $this->assertEquals(null, $country);
+        $this->assertNull($country);
     }
 
     public function testGetCountryByIsoCode3Char()
     {
         $country = (new Countries())->getByIsoCode('USA');
 
-        $this->assertEquals(Country::class, get_class($country));
+        $this->assertInstanceOf(Country::class, $country);
         $this->assertEquals('United States', $country->name);
     }
 
@@ -44,7 +44,7 @@ final class BasicUsageTest extends TestCase
     {
         $country = (new Countries())->getByIsoCode('US');
 
-        $this->assertEquals(Country::class, get_class($country));
+        $this->assertInstanceOf(Country::class, $country);
         $this->assertEquals('United States', $country->name);
     }
 
@@ -52,7 +52,7 @@ final class BasicUsageTest extends TestCase
     {
         $country = (new Countries())->getByIsoCode('UKJ');
 
-        $this->assertEquals(null, $country);
+        $this->assertNull($country);
     }
 
     public function testGetCountriesByLanguages()
@@ -62,8 +62,8 @@ final class BasicUsageTest extends TestCase
         $this->assertEquals(5, count($countries));
 
         foreach ($countries as $country) {
-            $this->assertEquals(Country::class, get_class($country));
-            $this->assertTrue(in_array('German', $country->languages));
+            $this->assertInstanceOf(Country::class, $country);
+            $this->assertContains('German', $country->languages);
         }
     }
 }

--- a/tests/Unit/MissingDataFileTest.php
+++ b/tests/Unit/MissingDataFileTest.php
@@ -24,6 +24,8 @@ final class MissingDataFileTest extends TestCase
     public function testRetrievingAllCountriesWithNoDataFile()
     {
         $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to retrieve MledozeCountries JSON data file. Have you ran composer update?');
+
         $countries = (new Countries())->all();
     }
 }


### PR DESCRIPTION
# Changed log
- Add `php-7.2` and `php-nightly` tests in Travis CI build.
Let the `php-nightly` test allow to be failed and nobody can guarantee that it will be successful every time.

- Using PHPUnit version `^6.5` and it's for `php-7.*` versions.

- Using the correct assertions to assert the current values.